### PR TITLE
added babel-polyfill to devDependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,5 @@
   },
   "dependencies": {
     "jsrsasign": "^5.0.7"
-  },
-  "peerDependencies": {
-    "babel-polyfill": ">=6.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-transform-es2015-classes": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
+    "babel-polyfill": "^6.9.0",
     "chai": "^3.5.0",
     "express": "^4.13.4",
     "gulp": "^3.9.1",


### PR DESCRIPTION
fixes #40
Depending on your version of npm your mileage will vary with your package.json file.

Starting with npm 3.0 peerDependencies are no longer automatically installed, instead they just warn the user.

This means when I followed the guide I ran npm install and npm run build and got build failure.

To fix this I have added it as a dev dependancy. I however do not understand anything babel so it's being a dev-dependency might be wrong.

If you want to read more about peerDependancies this is a good post: https://codingwithspike.wordpress.com/2016/01/21/dealing-with-the-deprecation-of-peerdependencies-in-npm-3/