### PR TITLE
include keys without the use parameter

### DIFF
--- a/src/MetadataService.js
+++ b/src/MetadataService.js
@@ -110,7 +110,7 @@ export default class MetadataService {
         Log.info("MetadataService._filterSigningKeys", keys);
 
         return keys.filter(item => {
-            return item.use === "sig";
+            return item.use === "sig" || (item.use === undefined && item.kid !== undefined);
         });
     }
 }

--- a/src/SigninResponse.js
+++ b/src/SigninResponse.js
@@ -50,6 +50,6 @@ export default class SigninResponse {
     }
     
     get isOpenIdConnect(){
-        return this.scopes.indexOf(OidcScope) >= 0;
+		return this.scopes.indexOf(OidcScope) >= 0 || (this.scope === undefined && this.id_token !== undefined); //scope is optional if same as requested
     }
 }

--- a/test/unit/MetadataService.spec.js
+++ b/test/unit/MetadataService.spec.js
@@ -369,6 +369,9 @@ describe("MetadataService", function() {
                 {
                     use:'enc',
                     kid:"test"
+                },
+                {
+                    kid:"test_use_not_present"
                 }]
             });
 
@@ -378,6 +381,9 @@ describe("MetadataService", function() {
                 keys.should.deep.equal([{
                     use:'sig',
                     kid:"test"
+                },
+                {
+                    kid:"test_use_not_present"
                 }]);
                 done();
             })

--- a/test/unit/SigninResponse.spec.js
+++ b/test/unit/SigninResponse.spec.js
@@ -140,6 +140,12 @@ describe("SigninResponse", function () {
 
             subject = new SigninResponse("scope=foo%20bar");
             subject.isOpenIdConnect.should.be.false;
+
+            subject = new SigninResponse("scope=foo%20bar&id_token=foo");
+            subject.isOpenIdConnect.should.be.false;
+
+            subject = new SigninResponse("id_token=foo");
+            subject.isOpenIdConnect.should.be.true;
         });
     });
 


### PR DESCRIPTION
1st commit: As per specification (https://tools.ietf.org/html/draft-ietf-jose-json-web-key-41#section-4.2), the "use" parameter is optional in the JWK definition on the server side, so I suggest to include these to the list of signatures.
2nd commit: In the token response, the openid provider is not required to repeat the scopes of the id token if the returned scope is the same as the one requested. 
Scope doesn't figure in the list of : http://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken2
In the specs of OAuth https://tools.ietf.org/html/rfc6749#section-4.2.2
 scope
         OPTIONAL, if identical to the scope requested by the client;
         otherwise, REQUIRED.  The scope of the access token as
         described by Section 3.3.
